### PR TITLE
Feature/migrate nested examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.6
+
+- Fix validation and tarball creation on Windows
+
 ## 0.1.5
 
 - fix [case sensitivity issue](https://github.com/spark/particle-library-manager/issues/17)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "particle-library-manager",
   "description": "particle library management package",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "author": "mat@particle.io",
   "repository": {
     "type": "git",

--- a/resources/libraries/library-v1-nested-examples/.gitignore
+++ b/resources/libraries/library-v1-nested-examples/.gitignore
@@ -1,0 +1,1 @@
+firmware/test/a.out

--- a/resources/libraries/library-v1-nested-examples/LICENSE
+++ b/resources/libraries/library-v1-nested-examples/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Joe Goggins
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/resources/libraries/library-v1-nested-examples/README.md
+++ b/resources/libraries/library-v1-nested-examples/README.md
@@ -1,0 +1,203 @@
+About
+===
+
+This repo serves as the specfication for what constitutes a valid Spark firmware library and an actual example library you can use as a reference when writing your own libraries.
+
+Spark Libraries can be used in the [Spark IDE](https://www.spark.io/build).
+_Soon_ you'll also be able to use them with the [Spark CLI](https://github.com/spark/spark-cli) and when compiling firmware locally with [Spark core-firmware](https://github.com/spark/core-firmware).
+
+## Table of Contents
+
+This README describes how to create libraries as well as the Spark Library Spec.
+
+The other files constitute the Spark Library itself:
+
+  - file, class, and function [naming conventions](doc/firmware-code-conventions.md)
+  - [example apps](firmware/examples) that illustrate library in action
+  - recommended approaches for [test-driven embedded development](firmware/test/RUNNING_TESTS.md)
+  - [metadata](spark.json) to set authors, license, official names
+  
+## Getting Started
+
+### 1. Define a temporary function to create library boilerplate
+
+Copy and paste this into a bash or zsh shell or .profile file.
+
+```bash
+create_spark_library() {
+	LIB_NAME="$1"
+
+	# Make sure a library name was passed
+	if [ -z "{$LIB_NAME}" ]; then
+		echo "Please provide a library name"
+		return
+	fi
+
+	echo "Creating $LIB_NAME"
+
+	# Create the directory if it doesn't exist
+	if [ ! -d "$LIB_NAME" ]; then
+		echo " ==> Creating ${LIB_NAME} directory"
+		mkdir $LIB_NAME
+	fi
+
+	# CD to the directory
+	cd $LIB_NAME
+
+
+	# Create the spark.json if it doesn't exist.
+	if [ ! -f "spark.json" ]; then
+		echo " ==> Creating spark.json file"
+		cat <<EOS > spark.json
+{
+	"name": "${LIB_NAME}",
+	"version": "0.0.1",
+	"author": "Someone <email@somesite.com>",
+	"license": "Choose a license",
+	"description": "Briefly describe this library"
+}
+EOS
+	fi
+
+
+	# Create the README file if it doesn't exist
+	if test -z "$(find ./ -maxdepth 1 -iname 'README*' -print -quit)"; then
+		echo " ==> Creating README.md"
+		cat <<EOS > README.md
+TODO: Describe your library and how to run the examples
+EOS
+	fi
+
+
+	# Create an empty license file if none exists
+	if test -z "$(find ./ -maxdepth 1 -iname 'LICENSE*' -print -quit)"; then
+		echo " ==> Creating LICENSE"
+		touch LICENSE
+	fi
+
+
+	# Create the firmware/examples directory if it doesn't exist
+	if [ ! -d "firmware/examples" ]; then
+		echo " ==> Creating firmware and firmware/examples directories"
+		mkdir -p firmware/examples
+	fi
+
+
+	# Create the firmware .h file if it doesn't exist
+	if [ ! -f "firmware/${LIB_NAME}.h" ]; then
+		echo " ==> Creating firmware/${LIB_NAME}.h"
+		touch firmware/${LIB_NAME}.h
+	fi
+
+
+	# Create the firmware .cpp file if it doesn't exist
+	if [ ! -f "firmware/${LIB_NAME}.cpp" ]; then
+		echo " ==> Creating firmware/${LIB_NAME}.cpp"
+		cat <<EOS > firmware/${LIB_NAME}.cpp
+#include "${LIB_NAME}.h"
+
+EOS
+	fi
+
+
+	# Create an empty example file if none exists
+	if test -z "$(find ./firmware/examples -maxdepth 1 -iname '*' -print -quit)"; then
+		echo " ==> Creating firmware/examples/example.cpp"
+		cat <<EOS > firmware/examples/example.cpp
+#include "${LIB_NAME}/${LIB_NAME}.h"
+
+// TODO write code that illustrates the best parts of what your library can do
+
+void setup {
+
+}
+
+
+void loop {
+
+}
+EOS
+	fi
+
+
+	# Initialize the git repo if it's not already one
+	if [ ! -d ".git" ]; then
+		GIT=`git init`
+		echo " ==> ${GIT}"
+	fi
+
+	echo "Creation of ${LIB_NAME} complete!"
+	echo "Check out https://github.com/spark/uber-library-example for more details"
+}
+
+```
+
+### 2. Call the function
+
+```bash
+create_spark_library this-is-my-library-name
+```
+
+- Replace `this-is-my-library-name` with the actual lib name. Your library's name should be lower-case, dash-separated.
+
+### 3. Edit the spark.json firmware .h and .cpp files
+
+- Use this repo as your guide to good library conventions.
+
+### 4. Create a GitHub repo and push to it
+
+### 5. Validate and publish via the Spark IDE
+
+To validate, import, and publish the library, jump into the IDE and click the "Add Library" button.
+
+## Getting Support
+
+- Check out the [libraries category on the Spark community site](https://community.spark.io/category/libraries) and post a thread there!
+- To file a bug; create a GitHub issue on this repo. Be sure to include details about how to replicate it.
+
+## The Spark Library Spec
+
+A Spark firmware library consists of:
+
+  - a GitHub REPO with a public clone url
+  - a JSON manifest (`spark.json`) at the root of the repo
+  - a bunch of files and directories at predictable locations (as illustrated here)
+
+More specifically, the collection of files comprising a Spark Library include the following:
+
+### Supporting Files
+
+1. a `spark.json` meta data file at the root of the library dir, very similar to NPM's `package.json`. (required)
+  1. The content of this file is validated via [this JSON Schema](https://www.spark.io/spark_library_schema_v1.json).
+
+2. a `README.md` that should provide one or more of the following sections
+  - _About_: An overview of the library; purpose, and description of dominant use cases.
+  - _Example Usage_: A simple snippet of code that illustrates the coolest part about your library.
+  - _Recommended Components_: Description and links to example components that can be used with the library.
+  - _Circuit Diagram: A schematic and breadboard view of how to wire up components with the library.
+  - _Learning Activities_: Proposed challenges to do more sophisticated things or hacks with the library.
+
+3. a `doc` directory of diagrams or other supporting documentation linked to from the `README.md`
+
+### Firmware
+
+1. a `firmware` folder containing code that will compile and execute on a Spark device. This folder contains:
+  1. A bunch of `.h`, `.cpp`, and `.c` files constituting the header and source code of the library.
+    1. _The main library header file_, intended to be included by users 
+      1. MUST be named the same as the "name" key in the `spark.json` + a `.h` extension. So if `name` is `uber-library-example`, then there should be a `uber-library-example.h` file in this folder. Other `.h` files, can exist, but this is the only one that is required.
+      2. SHOULD define a C++ style namespace in upper camel case style from the name (i.e. uber-library-example -> UberLibraryExample)
+    2. _The main definition file_, providing the bulk of the libraries public facing functionality
+      1. MUST be named like the header file, but with a `.cpp` extension. (uber-library-example.cpp)
+      2. SHOULD encapsulate all code inside a C++ style namespace in upper camel case style (i.e. UberLibraryExample)
+    3. Other optional `.h` files, when included in a user's app, will be available for inclusion in the Web IDE via `#include "uber-library-example/SOME_FILE_NAME.h"`.
+    4. Other optional `.cpp` files will be compiled by the Web IDE when the library is included in an app (and use `arm-none-eabi-g++` to build).
+    5. Other optional `.c` files will be compiled by the Web IDE when the library is included in an app (and use `arm-none-eabi-gcc` to build).
+  2. An `examples` sub-folder containing one or more flashable example firmware `.ino` or `.cpp` applications.
+    1. Each example file should be named descriptively and indicate what aspect of the library it illustrates. For example, a JSON library might have an example file like `parse-json-and-output-to-serial.cpp`.
+  3. A `test` sub-folder containing any associated tests
+
+## Contributing
+
+This repo is meant to serve as a place to consolidate insights from conversations had about libraries on the [Spark community site](https://community.spark.io), GitHub, or elsewhere on the web. "Proposals" to change the spec are pull requests that both define the conventions in the README AND illustrate them in underlying code. If something doesn't seem right, start a community thread or issue pull requests to stir up the conversation about how it ought to be!
+
+

--- a/resources/libraries/library-v1-nested-examples/doc/firmware-code-conventions.md
+++ b/resources/libraries/library-v1-nested-examples/doc/firmware-code-conventions.md
@@ -1,0 +1,15 @@
+### Firmware Code Conventions
+
+In general or where unspecified, use node.js + [npm](https://www.npmjs.org/doc/misc/npm-coding-style.html) for inspiration while respecting the pragmatic realities of embedded programming.  Specifically:
+
+- Use `all-lower-hyphen-css-case` for multiword filenames.
+- Use `UpperCamelCase` for class names (things that you'd pass to "new") and namespaces
+- Use `lowerCamelCase` for multiword identifiers when they refer to objects, functions, methods, members, or anything not specified in this section.
+- Use `CAPS_SNAKE_CASE` for constants, things that should never change and are rarely used.
+
+When using an acronym like `LED` or `JSON` in a class name, file name, or other context above, don't necessarily use all caps.  Instead, let the convention drive the spelling. For example, a class that blinks LEDs would be called `LedBlinker`, and live in a file called `led-blinker.cpp`
+
+- Use two spaces for indentation.
+- Prefix variables or functions with an underscore (`_`) when indended for very narrow, restricted, local usage.
+- Functions or methods that begin with the name `begin`, are meant to be called in the `setup()` function.
+- Curly Brackets should go on the next line after a class or function.

--- a/resources/libraries/library-v1-nested-examples/firmware/a-c-example.c
+++ b/resources/libraries/library-v1-nested-examples/firmware/a-c-example.c
@@ -1,0 +1,3 @@
+int some_helper() {
+  return 1;
+}

--- a/resources/libraries/library-v1-nested-examples/firmware/examples/blink-an-led-slower/blink-an-led-slower.cpp
+++ b/resources/libraries/library-v1-nested-examples/firmware/examples/blink-an-led-slower/blink-an-led-slower.cpp
@@ -1,0 +1,18 @@
+// IMPORTANT: When including a library in a firmware app, a sub dir prefix is needed
+// before the particular .h file.
+#include "uber-library-example/uber-library-example.h"
+
+// Initialize objects from the lib; be sure not to call anything
+// that requires hardware be initialized here, put those in setup()
+UberLibraryExample::Pin outputPin(D7);
+
+void setup() {
+  // Call functions on initialized library objects that require hardware
+  // to be wired up correct and available.
+  outputPin.beginInPinMode(OUTPUT);
+}
+
+void loop() {
+  // Use the library's initialized objects and functions
+  outputPin.modulateAtFrequency(50);
+}

--- a/resources/libraries/library-v1-nested-examples/firmware/examples/blink-an-led-very-slow/blink-an-led-very-slow.cpp
+++ b/resources/libraries/library-v1-nested-examples/firmware/examples/blink-an-led-very-slow/blink-an-led-very-slow.cpp
@@ -1,0 +1,9 @@
+#include "uber-library-example/uber-library-example.h"
+UberLibraryExample::Pin outputPin(D7);
+void setup() {
+  outputPin.beginInPinMode(OUTPUT);
+}
+
+void loop() {
+  outputPin.modulateAtFrequency(3000);
+}

--- a/resources/libraries/library-v1-nested-examples/firmware/examples/blink-an-led/blink-an-led.cpp
+++ b/resources/libraries/library-v1-nested-examples/firmware/examples/blink-an-led/blink-an-led.cpp
@@ -1,0 +1,18 @@
+// IMPORTANT: When including a library in a firmware app, a sub dir prefix is needed
+// before the particular .h file.
+#include "uber-library-example/uber-library-example.h"
+
+// Initialize objects from the lib; be sure not to call anything
+// that requires hardware be initialized here, put those in setup()
+UberLibraryExample::Pin outputPin(D7);
+
+void setup() {
+  // Call functions on initialized library objects that require hardware
+  // to be wired up correct and available.
+  outputPin.beginInPinMode(OUTPUT);
+}
+
+void loop() {
+  // Use the library's initialized objects and functions
+  outputPin.modulateAtFrequency(300);
+}

--- a/resources/libraries/library-v1-nested-examples/firmware/test/RUNNING_TESTS.md
+++ b/resources/libraries/library-v1-nested-examples/firmware/test/RUNNING_TESTS.md
@@ -1,0 +1,30 @@
+How to Run Tests
+===
+
+We're currently not sure what the best way to do [test driven embedded development](http://pragprog.com/book/jgade/test-driven-development-for-embedded-c) for Spark is.  Here's what we know about how a Spark library should be unit tested:
+
+Desired Developer Experience
+---
+
+The user of a library to be able to do:
+
+    git clone the-library.git
+    cd the-library/firmware/test
+    make test
+
+And see a bunch of test output like this:
+
+    running unit tests ......
+    test/test1.cpp:343: error: Failure in UberLibraryExample.blabla: false
+
+- Unit tests should run on a regular computer, not a Spark Core.
+- A developer should be able to cd into `firmware/test` and type `make` to run the unit tests (as illustrated above)
+- The tests should stub out Spark specific functionality so the code compiles and runs using on a
+  standard GNU C++ compiler.
+- When the compiled binary is run, it should print out a "." for each successful test. Failing tests should have a descriptive name and point to the file and line number of the test.
+- When any test fails, the binary should return a non-zero exit code.
+
+How to help out
+---
+
+If you have ideas about how to do this, please start a conversation at [community.spark.io](http://community.spark.io), or fork this repository and issue a pull request that illustrates how to do unit testing of a Spark Library.

--- a/resources/libraries/library-v1-nested-examples/firmware/test/makefile
+++ b/resources/libraries/library-v1-nested-examples/firmware/test/makefile
@@ -1,0 +1,10 @@
+# TODO: Figure out how to stub out the fact that
+# a libraries main .cpp file does `#include "uber-library-example/uber-library-example.h"`
+#
+CPP = g++
+RM = rm -f
+MKDIR = mkdir -p
+INCLUDE_DIRS += ..
+all:
+	$(CPP) -I $(INCLUDE_DIRS) test1.cpp
+	./a.out

--- a/resources/libraries/library-v1-nested-examples/firmware/test/test1.cpp
+++ b/resources/libraries/library-v1-nested-examples/firmware/test/test1.cpp
@@ -1,0 +1,28 @@
+// GNU c string lib
+#include <iostream>
+
+// Stubs from Spark land
+#define D7 7
+typedef enum PinMode 
+{
+  OUTPUT,
+  INPUT,
+  INPUT_PULLUP,
+  INPUT_PULLDOWN,
+  AF_OUTPUT_PUSHPULL,	//Used internally for Alternate Function Output PushPull(TIM, UART, SPI etc)
+  AF_OUTPUT_DRAIN,		//Used internally for Alternate Function Output Drain(I2C etc). External pullup resistors required.
+  AN_INPUT  			//Used internally for ADC Input
+} PinMode;
+
+#include "uber-library-example.h"
+
+int main()
+{
+  // TODO: Figure out how run the library's example code and do unit tests against it.
+	// UberLibraryExample::Pin outputPin(D7);
+  // outputPin.beginInPinMode(OUTPUT);
+  // outputPin.modulateAtFrequency(300);
+  // UberLibraryExample::Pin pin(D7);
+	std::cout << "ok" << std::endl;
+	return 0;
+}

--- a/resources/libraries/library-v1-nested-examples/firmware/uber-library-example.cpp
+++ b/resources/libraries/library-v1-nested-examples/firmware/uber-library-example.cpp
@@ -1,0 +1,59 @@
+// NOTE/NUANCE: When including WITHIN a library, no sub-dir prefix is needed.
+#include "uber-library-example.h"
+
+// Constructor
+UberLibraryExample::Pin::Pin(int _number)
+{
+  number = _number;
+  state = LOW;
+}
+
+// Initializers that should be called in the `setup()` function
+void UberLibraryExample::Pin::beginInPinMode(PinMode _pinMode)
+{
+  pinMode(number, _pinMode); 
+}
+
+// Main API functions that the library provides
+// typically called in `loop()` or `setup()` functions
+void UberLibraryExample::Pin::modulateAtFrequency(int _ms)
+{
+  setHigh();
+  delay(_ms);
+  setLow();
+  delay(_ms);
+}
+
+// Getters
+int UberLibraryExample::Pin::getNumber()
+{
+  return number;
+}
+bool UberLibraryExample::Pin::getState()
+{
+  return state;
+}
+bool UberLibraryExample::Pin::getMode()
+{
+  return mode;
+}
+bool UberLibraryExample::Pin::isHigh()
+{
+  return state == HIGH ? true : false;
+}
+
+// Setters
+void UberLibraryExample::Pin::setHigh()
+{
+  state = HIGH;
+  setActualPinState();
+}
+void UberLibraryExample::Pin::setLow()
+{
+  state = LOW;
+  setActualPinState();
+}
+void UberLibraryExample::Pin::setActualPinState()
+{
+  digitalWrite(number, state);
+}

--- a/resources/libraries/library-v1-nested-examples/firmware/uber-library-example.h
+++ b/resources/libraries/library-v1-nested-examples/firmware/uber-library-example.h
@@ -1,0 +1,36 @@
+#ifndef _UBER_LIBRARY_EXAMPLE
+#define _UBER_LIBRARY_EXAMPLE
+
+// Make library cross-compatiable
+// with Arduino, GNU C++ for tests, and Spark.
+//#if defined(ARDUINO) && ARDUINO >= 100
+//#include "Arduino.h"
+//#elif defined(SPARK)
+//#include "application.h"
+//#endif
+
+// TEMPORARY UNTIL the stuff that supports the code above is deployed to the build IDE
+#include "application.h"
+namespace UberLibraryExample
+{
+  class Pin
+  {
+    private:
+      int number;
+      int mode;
+      bool state;
+    public:
+      Pin(int _number);
+      void beginInPinMode(PinMode _pinMode);
+      void modulateAtFrequency(int _ms);
+      int getNumber();
+      bool getState();
+      bool getMode();
+      bool isHigh();
+      void setHigh();
+      void setLow();
+      void setActualPinState();
+  };
+}
+
+#endif

--- a/resources/libraries/library-v1-nested-examples/spark.json
+++ b/resources/libraries/library-v1-nested-examples/spark.json
@@ -1,0 +1,7 @@
+{
+  "name": "uber-library-example",
+  "author": "Joe Goggins <joe@particle.io>",
+  "license": "MIT",
+  "version": "0.0.10",
+  "description": "A simple library that illustrates coding conventions of a Spark Library"
+}

--- a/resources/libraries/library-v2-nested-examples/.gitignore
+++ b/resources/libraries/library-v2-nested-examples/.gitignore
@@ -1,0 +1,1 @@
+firmware/test/a.out

--- a/resources/libraries/library-v2-nested-examples/LICENSE
+++ b/resources/libraries/library-v2-nested-examples/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Joe Goggins
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/resources/libraries/library-v2-nested-examples/README.md
+++ b/resources/libraries/library-v2-nested-examples/README.md
@@ -1,0 +1,203 @@
+About
+===
+
+This repo serves as the specfication for what constitutes a valid Spark firmware library and an actual example library you can use as a reference when writing your own libraries.
+
+Spark Libraries can be used in the [Spark IDE](https://www.spark.io/build).
+_Soon_ you'll also be able to use them with the [Spark CLI](https://github.com/spark/spark-cli) and when compiling firmware locally with [Spark core-firmware](https://github.com/spark/core-firmware).
+
+## Table of Contents
+
+This README describes how to create libraries as well as the Spark Library Spec.
+
+The other files constitute the Spark Library itself:
+
+  - file, class, and function [naming conventions](doc/firmware-code-conventions.md)
+  - [example apps](firmware/examples) that illustrate library in action
+  - recommended approaches for [test-driven embedded development](firmware/test/RUNNING_TESTS.md)
+  - [metadata](spark.json) to set authors, license, official names
+  
+## Getting Started
+
+### 1. Define a temporary function to create library boilerplate
+
+Copy and paste this into a bash or zsh shell or .profile file.
+
+```bash
+create_spark_library() {
+	LIB_NAME="$1"
+
+	# Make sure a library name was passed
+	if [ -z "{$LIB_NAME}" ]; then
+		echo "Please provide a library name"
+		return
+	fi
+
+	echo "Creating $LIB_NAME"
+
+	# Create the directory if it doesn't exist
+	if [ ! -d "$LIB_NAME" ]; then
+		echo " ==> Creating ${LIB_NAME} directory"
+		mkdir $LIB_NAME
+	fi
+
+	# CD to the directory
+	cd $LIB_NAME
+
+
+	# Create the spark.json if it doesn't exist.
+	if [ ! -f "spark.json" ]; then
+		echo " ==> Creating spark.json file"
+		cat <<EOS > spark.json
+{
+	"name": "${LIB_NAME}",
+	"version": "0.0.1",
+	"author": "Someone <email@somesite.com>",
+	"license": "Choose a license",
+	"description": "Briefly describe this library"
+}
+EOS
+	fi
+
+
+	# Create the README file if it doesn't exist
+	if test -z "$(find ./ -maxdepth 1 -iname 'README*' -print -quit)"; then
+		echo " ==> Creating README.md"
+		cat <<EOS > README.md
+TODO: Describe your library and how to run the examples
+EOS
+	fi
+
+
+	# Create an empty license file if none exists
+	if test -z "$(find ./ -maxdepth 1 -iname 'LICENSE*' -print -quit)"; then
+		echo " ==> Creating LICENSE"
+		touch LICENSE
+	fi
+
+
+	# Create the firmware/examples directory if it doesn't exist
+	if [ ! -d "firmware/examples" ]; then
+		echo " ==> Creating firmware and firmware/examples directories"
+		mkdir -p firmware/examples
+	fi
+
+
+	# Create the firmware .h file if it doesn't exist
+	if [ ! -f "firmware/${LIB_NAME}.h" ]; then
+		echo " ==> Creating firmware/${LIB_NAME}.h"
+		touch firmware/${LIB_NAME}.h
+	fi
+
+
+	# Create the firmware .cpp file if it doesn't exist
+	if [ ! -f "firmware/${LIB_NAME}.cpp" ]; then
+		echo " ==> Creating firmware/${LIB_NAME}.cpp"
+		cat <<EOS > firmware/${LIB_NAME}.cpp
+#include "${LIB_NAME}.h"
+
+EOS
+	fi
+
+
+	# Create an empty example file if none exists
+	if test -z "$(find ./firmware/examples -maxdepth 1 -iname '*' -print -quit)"; then
+		echo " ==> Creating firmware/examples/example.cpp"
+		cat <<EOS > firmware/examples/example.cpp
+#include "${LIB_NAME}/${LIB_NAME}.h"
+
+// TODO write code that illustrates the best parts of what your library can do
+
+void setup {
+
+}
+
+
+void loop {
+
+}
+EOS
+	fi
+
+
+	# Initialize the git repo if it's not already one
+	if [ ! -d ".git" ]; then
+		GIT=`git init`
+		echo " ==> ${GIT}"
+	fi
+
+	echo "Creation of ${LIB_NAME} complete!"
+	echo "Check out https://github.com/spark/uber-library-example for more details"
+}
+
+```
+
+### 2. Call the function
+
+```bash
+create_spark_library this-is-my-library-name
+```
+
+- Replace `this-is-my-library-name` with the actual lib name. Your library's name should be lower-case, dash-separated.
+
+### 3. Edit the spark.json firmware .h and .cpp files
+
+- Use this repo as your guide to good library conventions.
+
+### 4. Create a GitHub repo and push to it
+
+### 5. Validate and publish via the Spark IDE
+
+To validate, import, and publish the library, jump into the IDE and click the "Add Library" button.
+
+## Getting Support
+
+- Check out the [libraries category on the Spark community site](https://community.spark.io/category/libraries) and post a thread there!
+- To file a bug; create a GitHub issue on this repo. Be sure to include details about how to replicate it.
+
+## The Spark Library Spec
+
+A Spark firmware library consists of:
+
+  - a GitHub REPO with a public clone url
+  - a JSON manifest (`spark.json`) at the root of the repo
+  - a bunch of files and directories at predictable locations (as illustrated here)
+
+More specifically, the collection of files comprising a Spark Library include the following:
+
+### Supporting Files
+
+1. a `spark.json` meta data file at the root of the library dir, very similar to NPM's `package.json`. (required)
+  1. The content of this file is validated via [this JSON Schema](https://www.spark.io/spark_library_schema_v1.json).
+
+2. a `README.md` that should provide one or more of the following sections
+  - _About_: An overview of the library; purpose, and description of dominant use cases.
+  - _Example Usage_: A simple snippet of code that illustrates the coolest part about your library.
+  - _Recommended Components_: Description and links to example components that can be used with the library.
+  - _Circuit Diagram: A schematic and breadboard view of how to wire up components with the library.
+  - _Learning Activities_: Proposed challenges to do more sophisticated things or hacks with the library.
+
+3. a `doc` directory of diagrams or other supporting documentation linked to from the `README.md`
+
+### Firmware
+
+1. a `firmware` folder containing code that will compile and execute on a Spark device. This folder contains:
+  1. A bunch of `.h`, `.cpp`, and `.c` files constituting the header and source code of the library.
+    1. _The main library header file_, intended to be included by users 
+      1. MUST be named the same as the "name" key in the `spark.json` + a `.h` extension. So if `name` is `uber-library-example`, then there should be a `uber-library-example.h` file in this folder. Other `.h` files, can exist, but this is the only one that is required.
+      2. SHOULD define a C++ style namespace in upper camel case style from the name (i.e. uber-library-example -> UberLibraryExample)
+    2. _The main definition file_, providing the bulk of the libraries public facing functionality
+      1. MUST be named like the header file, but with a `.cpp` extension. (uber-library-example.cpp)
+      2. SHOULD encapsulate all code inside a C++ style namespace in upper camel case style (i.e. UberLibraryExample)
+    3. Other optional `.h` files, when included in a user's app, will be available for inclusion in the Web IDE via `#include "uber-library-example/SOME_FILE_NAME.h"`.
+    4. Other optional `.cpp` files will be compiled by the Web IDE when the library is included in an app (and use `arm-none-eabi-g++` to build).
+    5. Other optional `.c` files will be compiled by the Web IDE when the library is included in an app (and use `arm-none-eabi-gcc` to build).
+  2. An `examples` sub-folder containing one or more flashable example firmware `.ino` or `.cpp` applications.
+    1. Each example file should be named descriptively and indicate what aspect of the library it illustrates. For example, a JSON library might have an example file like `parse-json-and-output-to-serial.cpp`.
+  3. A `test` sub-folder containing any associated tests
+
+## Contributing
+
+This repo is meant to serve as a place to consolidate insights from conversations had about libraries on the [Spark community site](https://community.spark.io), GitHub, or elsewhere on the web. "Proposals" to change the spec are pull requests that both define the conventions in the README AND illustrate them in underlying code. If something doesn't seem right, start a community thread or issue pull requests to stir up the conversation about how it ought to be!
+
+

--- a/resources/libraries/library-v2-nested-examples/doc/firmware-code-conventions.md
+++ b/resources/libraries/library-v2-nested-examples/doc/firmware-code-conventions.md
@@ -1,0 +1,15 @@
+### Firmware Code Conventions
+
+In general or where unspecified, use node.js + [npm](https://www.npmjs.org/doc/misc/npm-coding-style.html) for inspiration while respecting the pragmatic realities of embedded programming.  Specifically:
+
+- Use `all-lower-hyphen-css-case` for multiword filenames.
+- Use `UpperCamelCase` for class names (things that you'd pass to "new") and namespaces
+- Use `lowerCamelCase` for multiword identifiers when they refer to objects, functions, methods, members, or anything not specified in this section.
+- Use `CAPS_SNAKE_CASE` for constants, things that should never change and are rarely used.
+
+When using an acronym like `LED` or `JSON` in a class name, file name, or other context above, don't necessarily use all caps.  Instead, let the convention drive the spelling. For example, a class that blinks LEDs would be called `LedBlinker`, and live in a file called `led-blinker.cpp`
+
+- Use two spaces for indentation.
+- Prefix variables or functions with an underscore (`_`) when indended for very narrow, restricted, local usage.
+- Functions or methods that begin with the name `begin`, are meant to be called in the `setup()` function.
+- Curly Brackets should go on the next line after a class or function.

--- a/resources/libraries/library-v2-nested-examples/examples/blink-an-led-slower/blink-an-led-slower.cpp
+++ b/resources/libraries/library-v2-nested-examples/examples/blink-an-led-slower/blink-an-led-slower.cpp
@@ -1,0 +1,18 @@
+// IMPORTANT: When including a library in a firmware app, a sub dir prefix is needed
+// before the particular .h file.
+#include "uber-library-example.h"
+
+// Initialize objects from the lib; be sure not to call anything
+// that requires hardware be initialized here, put those in setup()
+UberLibraryExample::Pin outputPin(D7);
+
+void setup() {
+  // Call functions on initialized library objects that require hardware
+  // to be wired up correct and available.
+  outputPin.beginInPinMode(OUTPUT);
+}
+
+void loop() {
+  // Use the library's initialized objects and functions
+  outputPin.modulateAtFrequency(50);
+}

--- a/resources/libraries/library-v2-nested-examples/examples/blink-an-led-very-slow/blink-an-led-very-slow.cpp
+++ b/resources/libraries/library-v2-nested-examples/examples/blink-an-led-very-slow/blink-an-led-very-slow.cpp
@@ -1,0 +1,9 @@
+#include "uber-library-example.h"
+UberLibraryExample::Pin outputPin(D7);
+void setup() {
+  outputPin.beginInPinMode(OUTPUT);
+}
+
+void loop() {
+  outputPin.modulateAtFrequency(3000);
+}

--- a/resources/libraries/library-v2-nested-examples/examples/blink-an-led/blink-an-led.cpp
+++ b/resources/libraries/library-v2-nested-examples/examples/blink-an-led/blink-an-led.cpp
@@ -1,0 +1,18 @@
+// IMPORTANT: When including a library in a firmware app, a sub dir prefix is needed
+// before the particular .h file.
+#include "uber-library-example.h"
+
+// Initialize objects from the lib; be sure not to call anything
+// that requires hardware be initialized here, put those in setup()
+UberLibraryExample::Pin outputPin(D7);
+
+void setup() {
+  // Call functions on initialized library objects that require hardware
+  // to be wired up correct and available.
+  outputPin.beginInPinMode(OUTPUT);
+}
+
+void loop() {
+  // Use the library's initialized objects and functions
+  outputPin.modulateAtFrequency(300);
+}

--- a/resources/libraries/library-v2-nested-examples/library.properties
+++ b/resources/libraries/library-v2-nested-examples/library.properties
@@ -1,0 +1,5 @@
+name=uber-library-example
+version=0.0.10
+license=MIT
+author=Joe Goggins <joe@particle.io>
+sentence=A simple library that illustrates coding conventions of a Spark Library

--- a/resources/libraries/library-v2-nested-examples/src/a-c-example.c
+++ b/resources/libraries/library-v2-nested-examples/src/a-c-example.c
@@ -1,0 +1,3 @@
+int some_helper() {
+  return 1;
+}

--- a/resources/libraries/library-v2-nested-examples/src/uber-library-example.cpp
+++ b/resources/libraries/library-v2-nested-examples/src/uber-library-example.cpp
@@ -1,0 +1,59 @@
+// NOTE/NUANCE: When including WITHIN a library, no sub-dir prefix is needed.
+#include "uber-library-example.h"
+
+// Constructor
+UberLibraryExample::Pin::Pin(int _number)
+{
+  number = _number;
+  state = LOW;
+}
+
+// Initializers that should be called in the `setup()` function
+void UberLibraryExample::Pin::beginInPinMode(PinMode _pinMode)
+{
+  pinMode(number, _pinMode); 
+}
+
+// Main API functions that the library provides
+// typically called in `loop()` or `setup()` functions
+void UberLibraryExample::Pin::modulateAtFrequency(int _ms)
+{
+  setHigh();
+  delay(_ms);
+  setLow();
+  delay(_ms);
+}
+
+// Getters
+int UberLibraryExample::Pin::getNumber()
+{
+  return number;
+}
+bool UberLibraryExample::Pin::getState()
+{
+  return state;
+}
+bool UberLibraryExample::Pin::getMode()
+{
+  return mode;
+}
+bool UberLibraryExample::Pin::isHigh()
+{
+  return state == HIGH ? true : false;
+}
+
+// Setters
+void UberLibraryExample::Pin::setHigh()
+{
+  state = HIGH;
+  setActualPinState();
+}
+void UberLibraryExample::Pin::setLow()
+{
+  state = LOW;
+  setActualPinState();
+}
+void UberLibraryExample::Pin::setActualPinState()
+{
+  digitalWrite(number, state);
+}

--- a/resources/libraries/library-v2-nested-examples/src/uber-library-example.h
+++ b/resources/libraries/library-v2-nested-examples/src/uber-library-example.h
@@ -1,0 +1,36 @@
+#ifndef _UBER_LIBRARY_EXAMPLE
+#define _UBER_LIBRARY_EXAMPLE
+
+// Make library cross-compatiable
+// with Arduino, GNU C++ for tests, and Spark.
+//#if defined(ARDUINO) && ARDUINO >= 100
+//#include "Arduino.h"
+//#elif defined(SPARK)
+//#include "application.h"
+//#endif
+
+// TEMPORARY UNTIL the stuff that supports the code above is deployed to the build IDE
+#include "application.h"
+namespace UberLibraryExample
+{
+  class Pin
+  {
+    private:
+      int number;
+      int mode;
+      bool state;
+    public:
+      Pin(int _number);
+      void beginInPinMode(PinMode _pinMode);
+      void modulateAtFrequency(int _ms);
+      int getNumber();
+      bool getState();
+      bool getMode();
+      bool isHigh();
+      void setHigh();
+      void setLow();
+      void setActualPinState();
+  };
+}
+
+#endif

--- a/resources/libraries/library-v2-nested-examples/test/unit/RUNNING_TESTS.md
+++ b/resources/libraries/library-v2-nested-examples/test/unit/RUNNING_TESTS.md
@@ -1,0 +1,30 @@
+How to Run Tests
+===
+
+We're currently not sure what the best way to do [test driven embedded development](http://pragprog.com/book/jgade/test-driven-development-for-embedded-c) for Spark is.  Here's what we know about how a Spark library should be unit tested:
+
+Desired Developer Experience
+---
+
+The user of a library to be able to do:
+
+    git clone the-library.git
+    cd the-library/firmware/test
+    make test
+
+And see a bunch of test output like this:
+
+    running unit tests ......
+    test/test1.cpp:343: error: Failure in UberLibraryExample.blabla: false
+
+- Unit tests should run on a regular computer, not a Spark Core.
+- A developer should be able to cd into `firmware/test` and type `make` to run the unit tests (as illustrated above)
+- The tests should stub out Spark specific functionality so the code compiles and runs using on a
+  standard GNU C++ compiler.
+- When the compiled binary is run, it should print out a "." for each successful test. Failing tests should have a descriptive name and point to the file and line number of the test.
+- When any test fails, the binary should return a non-zero exit code.
+
+How to help out
+---
+
+If you have ideas about how to do this, please start a conversation at [community.spark.io](http://community.spark.io), or fork this repository and issue a pull request that illustrates how to do unit testing of a Spark Library.

--- a/resources/libraries/library-v2-nested-examples/test/unit/makefile
+++ b/resources/libraries/library-v2-nested-examples/test/unit/makefile
@@ -1,0 +1,10 @@
+# TODO: Figure out how to stub out the fact that
+# a libraries main .cpp file does `#include "uber-library-example/uber-library-example.h"`
+#
+CPP = g++
+RM = rm -f
+MKDIR = mkdir -p
+INCLUDE_DIRS += ..
+all:
+	$(CPP) -I $(INCLUDE_DIRS) test1.cpp
+	./a.out

--- a/resources/libraries/library-v2-nested-examples/test/unit/test1.cpp
+++ b/resources/libraries/library-v2-nested-examples/test/unit/test1.cpp
@@ -1,0 +1,28 @@
+// GNU c string lib
+#include <iostream>
+
+// Stubs from Spark land
+#define D7 7
+typedef enum PinMode 
+{
+  OUTPUT,
+  INPUT,
+  INPUT_PULLUP,
+  INPUT_PULLDOWN,
+  AF_OUTPUT_PUSHPULL,	//Used internally for Alternate Function Output PushPull(TIM, UART, SPI etc)
+  AF_OUTPUT_DRAIN,		//Used internally for Alternate Function Output Drain(I2C etc). External pullup resistors required.
+  AN_INPUT  			//Used internally for ADC Input
+} PinMode;
+
+#include "uber-library-example.h"
+
+int main()
+{
+  // TODO: Figure out how run the library's example code and do unit tests against it.
+	// UberLibraryExample::Pin outputPin(D7);
+  // outputPin.beginInPinMode(OUTPUT);
+  // outputPin.modulateAtFrequency(300);
+  // UberLibraryExample::Pin pin(D7);
+	std::cout << "ok" << std::endl;
+	return 0;
+}

--- a/src/librepo_fs.js
+++ b/src/librepo_fs.js
@@ -731,7 +731,11 @@ export class FileSystemLibraryRepository extends AbstractLibraryRepository {
 		const v2 = path.join(libdir, examplesDir);
 		const self = this;
 		function mapper(stat, example, filePath) {
-			return self.migrateExample(name, example, v1, v2);
+			if (stat.isFile()) {
+				return self.migrateExample(name, example, path.dirname(filePath), v2);
+			} else {
+				return mapActionDir(filePath, mapper, (promises) => promises);
+			}
 		}
 
 		return this.fileStat(v1).then((stat) => {

--- a/test/librepo_fs.spec.js
+++ b/test/librepo_fs.spec.js
@@ -119,6 +119,10 @@ describe('File System', () => {
 		return assertMigrate('library-v1-noexamples', 'library-v2-noexamples');
 	});
 
+	it('can migrate a v1 library with nested examples to v2 format', () => {
+		return assertMigrate('library-v1-nested-examples', 'library-v2-nested-examples');
+	});
+
 
 	describe('LibraryContributor', () => {
 


### PR DESCRIPTION
Properly migrate the examples if they are in a nested folder: `firmware/examples/blink-led/blink-led.cpp` ==> `examples/blink-led/blink-led.cpp`

