### PR TITLE
library files whitelist

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "fs-extra": "^2.0.0",
     "gunzip-maybe": "^1.3.1",
     "klaw": "^1.3.1",
+    "minimatch": "^3.0.3",
     "mkdirp": "^0.5.1",
     "particle-api-js": "^6.4.1",
     "properties-parser": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "eslint": "^3.15.0",
     "eslint-config-particle": "^2.0.0",
     "mocha": "^3.0.2",
-    "mock-fs": "^4.0.0",
+    "mock-fs": "^4.2.0",
     "pre-commit": "^1.1.3",
     "promise.prototype.finally": "^2.0.1",
     "should": "^11.2.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "devDependencies": {
     "babel-cli": "^6.9.0",
     "babel-eslint": "^7.1.1",
-    "babel-istanbul": "^0.12.1",
+    "babel-istanbul": "^0.12.2",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-transform-async-to-generator": "^6.8.0",
     "babel-polyfill": "^6.5.0",

--- a/src/libcontribute.js
+++ b/src/libcontribute.js
@@ -1,4 +1,5 @@
 import { validateLibrary } from './validation';
+import EventEmitter from 'events';
 
 import zlib from 'zlib';
 import tarfs from 'tar-fs';
@@ -14,13 +15,14 @@ const defaultWhitelist = ['*.ino', '*.pde', '*.cpp', '*.c', '*.c++', '*.h', '*.h
 /**
  * Creates the tar.gz stream for sending to the library api to contribute the library.
  */
-export class LibraryContributor {
+export class LibraryContributor extends EventEmitter {
 
 	/**
 	 * @param {FileSystemLibraryRepository} repo  The repo containing the library.
 	 * @param {Particle.Client} client  The particle-api.js client.
 	 */
 	constructor({ repo, client }) {
+		super();
 		Object.assign(this, { repo, client });
 	}
 
@@ -45,6 +47,7 @@ export class LibraryContributor {
 		// case-insensitive match
 		const matcher = minimatch.filter(expr, { matchBase: true, dot: true, nocase: true });
 		return (name) => {
+			const originalName = name;
 			const isdir = this._isdirectory(name);
 			name = path.relative(dir, name);    // ensure it's relative
 			if (isdir) {                        // designate as a directory
@@ -61,6 +64,7 @@ export class LibraryContributor {
 			} else {
 				result = !matcher(name);
 			}
+			this.emit('file', originalName, result);
 			return result;
 		};
 	}

--- a/src/libinit.js
+++ b/src/libinit.js
@@ -60,8 +60,7 @@ function validationError(validation) {
 export const LibraryInitGeneratorMixin = (B) => class extends B {
 
 	constructor(...args) {
-		/* istanbul ignore next */
-		super(...args);
+		super(...args); 		/* istanbul ignore next: coverage bug? */
 	}
 
 	/**
@@ -247,8 +246,7 @@ export function buildLibraryInitGeneratorClass() {
 	class LibraryInitGenerator extends LibraryInitGeneratorMixin(gen) { // eslint-disable-line new-cap
 
 		constructor(...args) {
-			/* istanbul ignore next */
-			super(...args);
+			super(...args);  			/* istanbul ignore next: coverage bug? */
 			this.sourceRoot(sourceRoot());
 			this._initializeOptions();
 			this._checkFields();
@@ -274,4 +272,5 @@ export function buildLibraryInitGeneratorClass() {
 
 
 // keep all branches  of the ES6 transpilled code executed
+/* istanbul ignore next: not executed on node 7 */
 export default () => {};

--- a/src/librepo_fs.js
+++ b/src/librepo_fs.js
@@ -263,7 +263,7 @@ export class FileSystemLibraryRepository extends AbstractLibraryRepository {
 	 * library file.
 	 */
 	libraryFileName(libraryName, fileName, fileExt) {
-		return this.libraryDirectory(libraryName) + fileName + '.' + fileExt;
+		return this.libraryDirectory(libraryName) + fileName + (fileExt ? '.' + fileExt : '');
 	}
 
 	/**

--- a/src/librepo_fs.js
+++ b/src/librepo_fs.js
@@ -1119,5 +1119,6 @@ export function isLibraryExample(file, cwd=process.cwd()) {
 
 
 // keep all branches  of the ES6 transpilled code executed
+/* istanbul ignore next: not executed on node 7 */
 export default () => {};
 

--- a/test/libcontribute.spec.js
+++ b/test/libcontribute.spec.js
@@ -190,7 +190,12 @@ describe('LibraryContributor', () => {
 
 		for (const key of Object.keys(results)) {
 			it((results[key] ? 'allows' : 'rejects') + ' the file '+key, () => {
-				expect(filter(key)).to.be.eql(!results[key]);
+				const listener = sinon.stub();
+				sut.on('file', listener);
+				const ignored = !results[key];
+				expect(filter(key)).to.be.eql(ignored);
+				expect(listener).to.have.been.called;
+				expect(listener).to.have.been.calledWith(key, ignored);
 			});
 		}
 

--- a/test/librepo_fs.spec.js
+++ b/test/librepo_fs.spec.js
@@ -291,6 +291,17 @@ describe('File System', () => {
 			const sut = FileSystemNamingStrategy.DIRECT;
 			expect(sut.matchesName({}, '')).to.be.true;
 		});
+
+		it('matches the descriptor name', () => {
+			const sut = FileSystemNamingStrategy.DIRECT;
+			expect(sut.matchesName({ name:'fred' }, 'fred')).to.be.true;
+		});
+
+		it('mismatches the descriptor name', () => {
+			const sut = FileSystemNamingStrategy.DIRECT;
+			expect(sut.matchesName({ name:'freddie' }, 'fred')).to.be.false;
+		});
+
 	});
 });
 

--- a/test/librepo_fs.spec.js
+++ b/test/librepo_fs.spec.js
@@ -23,6 +23,7 @@ import { LibraryContributor } from '../src/libcontribute';
 import { makeCompleteV2Lib } from './librepo_fs_mock.spec';
 import { makeTestLib } from './librepo_fs_mock.spec';
 import { NamingStrategy } from '../src/librepo_fs';
+import { MemoryLibraryFile } from '../src/librepo';
 const fs = require('fs');
 const path = require('path');
 
@@ -157,7 +158,10 @@ describe('File System', () => {
 			const tmpobj = tmp.dirSync();
 			const dir = tmpobj.name;
 			const repo = new FileSystemLibraryRepository(dir);
-			const lib = makeCompleteV2Lib(name, '1.2.3');
+			const lib = makeCompleteV2Lib(name, '1.2.3', [
+				new MemoryLibraryFile('big', 'duff', 'pdf', '# readme', 100),
+				new MemoryLibraryFile('.git/somefile', 'duff', '', '# readme', 101),
+			]);
 
 			const sut = new LibraryContributor({ repo, client });
 			const callback = sinon.stub();
@@ -187,10 +191,12 @@ describe('File System', () => {
 					});
 					return promise.then(() => {
 						expect(names).to.include('README.md');
-						expect(names).include('LICENSE.');
 						expect(names).include('library.properties');
 						expect(names).include('src/fred.cpp');
 						expect(names).include('src/fred.h');
+						expect(names).include('LICENSE');
+						expect(names).to.not.include('big.pdf');
+						expect(names).to.not.include('.git/something');
 
 						expect(callback).to.have.been.calledWith('validatingLibrary');
 						expect(callback).to.have.been.calledWith('contributingLibrary');

--- a/test/librepo_fs_mock.spec.js
+++ b/test/librepo_fs_mock.spec.js
@@ -972,8 +972,12 @@ describe('File System Mock', () => {
 
 		function createFilesAndComputePrefix(paths, relative, cwd) {
 			for (let p of paths) {
-				mkdirp(path.dirname(p));
-				fs.writeFileSync(p, '');
+				if (p.endsWith('/')) {
+					mkdirp(p);
+				} else {
+					mkdirp(path.dirname(p));
+					fs.writeFileSync(p, '');
+				}
 			}
 			const result = pathsCommonPrefix(paths, relative, cwd);
 			return result;
@@ -981,6 +985,7 @@ describe('File System Mock', () => {
 
 		it('computes the longest common prefix of several files and directories where filenames have a common prefix', () => {
 			const paths = [
+				path.join('/mydir', 'dir2', 'src')+'/',
 				path.join('/mydir', 'dir2', 'src', 'file.txt'),
 				path.join('/mydir', 'dir2', 'src', 'file2.txt'),
 				path.join('/mydir', 'dir2', 'src', 'fi', 'file2.txt')

--- a/test/librepo_fs_mock.spec.js
+++ b/test/librepo_fs_mock.spec.js
@@ -207,13 +207,13 @@ export function makeTestLib(name, version) {
 }
 
 
-export function makeCompleteV2Lib(name, version) {
+export function makeCompleteV2Lib(name, version, extraFiles=[]) {
 	const lib = makeLibrary(name, { name, version }, [
 		new MemoryLibraryFile('src/'+name, 'source', 'cpp', '// a cpp file', 1),
 		new MemoryLibraryFile('src/'+name, 'source', 'h', '// a header file', 2),
 		new MemoryLibraryFile('README', 'source', 'md', '# readme', 3),
 		new MemoryLibraryFile('LICENSE', 'source', '', '# license', 4),
-	]);
+	].concat(extraFiles));
 	return lib;
 }
 
@@ -378,6 +378,11 @@ describe('File System Mock', () => {
 		it('can fetch a filename from the library anem, file base and file extension', () => {
 			const sut = new FileSystemLibraryRepository('mydir');
 			expect(sut.libraryFileName('mylib', 'file', 'ext')).to.be.equal('mydir/mylib/file.ext');
+		});
+
+		it('can fetch a filename from the library anem, file base and empty extension', () => {
+			const sut = new FileSystemLibraryRepository('mydir');
+			expect(sut.libraryFileName('mylib', 'file')).to.be.equal('mydir/mylib/file');
 		});
 
 		it('can determine source code files', () => {


### PR DESCRIPTION
filters out files that do not match the whitelist. The default whitelist can be extended by adding the `whitelist` property, a comma-separated list of glob expressions, in `library.properties`

