### PR TITLE
The initializer sanitized the #include more than file names

### DIFF
--- a/src/init/templates/README.md
+++ b/src/init/templates/README.md
@@ -19,6 +19,7 @@ _TODO: update this README_
 Connect XYZ hardware, add the <%- name %> library to your project and follow this simple example:
 
 ```
+#include "<%- name %>.h"
 <%- Name_code %> <%- name_code %>;
 
 void setup() {

--- a/src/init/templates/examples/usage/usage.ino
+++ b/src/init/templates/examples/usage/usage.ino
@@ -1,6 +1,6 @@
 // Example usage for <%- name %> library by <%- author %>.
 
-#include "<%- name_code %>.h"
+#include "<%- name %>.h"
 
 // Initialize objects from the lib
 <%- Name_code %> <%- name_code %>;

--- a/src/init/templates/src/library.cpp
+++ b/src/init/templates/src/library.cpp
@@ -1,7 +1,7 @@
-/* <%- name_code %> library by <%- author %>
+/* <%- name %> library by <%- author %>
  */
 
-#include "<%- name_code %>.h"
+#include "<%- name %>.h"
 
 /**
  * Constructor.

--- a/src/init/templates/src/library.h
+++ b/src/init/templates/src/library.h
@@ -1,6 +1,6 @@
 #pragma once
 
-/* <%- name_code %> library by <%- author %>
+/* <%- name %> library by <%- author %>
  */
 
 // This will load the definition for common Particle variable types

--- a/test/generator/README.md
+++ b/test/generator/README.md
@@ -19,6 +19,7 @@ _TODO: update this README_
 Connect XYZ hardware, add the nominative library to your project and follow this simple example:
 
 ```
+#include "nominative.h"
 Nominative nominative;
 
 void setup() {


### PR DESCRIPTION
For example, `my-lib` would generate `src/my-lib.h` but the example included `#include "mylib.h"`